### PR TITLE
Remove reference to old broccoli-yuidoc-fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var YuidocCompiler = require('broccoli-yuidoc-fork');
+var YuidocCompiler = require('broccoli-yuidoc');
 var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {


### PR DESCRIPTION
Cannot generate until the yuidoc compiler requires the right module
