### PR TITLE
Update readme to use new command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ once with some sensitive defaults.
 
 ### As an ember command
 
-This addon adds a new `yuidoc` command to ember-cli to generate the documentation on demand. 
+This addon adds a new `ember-cli-yuidoc` command to ember-cli to generate the documentation on demand. 
 
-Just run `ember yuidoc` and yours docs will apear in your output directory (`/docs` by default).
+Just run `ember ember-cli-yuidoc` and your docs will apear in your output directory (`/docs` by default).
 You probably want to add this folder to the `.gitignore`.
 
 ### Watch mode


### PR DESCRIPTION
In 5f0170611c85d the command `yuidoc` get renamed to `ember-cli-yuidoc`, due to community conventions. The commit title actually says "rename generator", so maybe the **command** (not the **generator**) got renamed by accident.