### PR TITLE
Read the external data from yuidoc.json

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -35,6 +35,7 @@ module.exports = {
       destDir: outDir,
       paths: config.options.paths || '.',
       version: getVersion(),
+      external: config.external || {},
       yuidoc: {
         linkNatives: true,
         quiet: true,


### PR DESCRIPTION
YUIDoc supports external data in `yuidoc.json`. See also https://github.com/yui/yuidoc/releases/tag/v0.4.0.