### PR TITLE
Make addon lookup external data same as YUIDoc tool

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -35,7 +35,7 @@ module.exports = {
       destDir: outDir,
       paths: config.options.paths || '.',
       version: getVersion(),
-      external: config.external || {},
+      external: config.external || config.options.external || {},
       yuidoc: {
         linkNatives: true,
         quiet: true,


### PR DESCRIPTION
YUIDoc tool and the addon will both find "external.data" at the top-level of yuidoc.json, but unfortunately the YUIDoc documentation says it's support to go in "options". The tool will find it here, but this addon won't. This fixes that and makes the lookup order the same.