### PR TITLE
Handle when `yuidocOptions` is missing and allow falsey values.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -4,6 +4,14 @@ var getVersion  = require('git-repo-version');
 var fs          = require('fs');
 var Y           = require('yuidocjs');
 
+function defaultOption(options, name, defaultValue) {
+  if (!options) {
+    return defaultValue;
+  }
+
+  return options.hasOwnProperty(name) ? options[name] : defaultValue;
+}
+
 module.exports = {
   generate: function generateYuidocOptions(){
     var config;
@@ -38,10 +46,10 @@ module.exports = {
       version: getVersion(),
       external: config.external || config.options.external || {},
       yuidoc: {
-        linkNatives: yuidocOptions.linkNatives || true,
-        quiet: yuidocOptions.quiet || true,
-        parseOnly: yuidocOptions.parseOnly || false,
-        lint: yuidocOptions.lint || false,
+        linkNatives: defaultOption(yuidocOptions, 'linkNatives',  true),
+        quiet: defaultOption(yuidocOptions, 'quiet', true),
+        parseOnly: defaultOption(yuidocOptions, 'parseOnly', false),
+        lint: defaultOption(yuidocOptions, 'lint', false),
         exclude: exclusions.join(',')
       }
     });


### PR DESCRIPTION
When `yuidocOptions` is undefined an error is thrown (`Cannot read property 'linkNatives' of undefined`).

Also, the prior version would not allow falsey values to override the defaults.