### PR TITLE
Add ignored paths

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -43,6 +43,7 @@ module.exports = {
       outdir: outDir,
       destDir: outDir,
       paths: config.options.paths || '.',
+      ignorePaths: ['tmp', 'node_modules'],
       version: getVersion(),
       external: config.external || config.options.external || {},
       yuidoc: {


### PR DESCRIPTION
YUIDoc can ignore paths when building a project. 0.8.1 the implementation is not very efficient, but after https://github.com/yui/yuidoc/pull/372 lands you should see this change significantly improve docs build times (and possibly fix builds- I cannot seem to finish building ember docs without it).