### PR TITLE
constently load all options

### DIFF
--- a/blueprints/ember-cli-yuidoc/index.js
+++ b/blueprints/ember-cli-yuidoc/index.js
@@ -12,12 +12,10 @@ module.exports = {
         paths: [],
         exclude: "vendor",
         outdir: "docs",
-        yuidoc: {
-          linkNatives: true,
-          quiet: true,
-          parseOnly: false,
-          lint: false
-        }
+        linkNatives: true,
+        quiet: true,
+        parseOnly: false,
+        lint: false
       }
     };
     if (pkginfo.keywords && pkginfo.keywords.indexOf('ember-addon') !== -1){

--- a/index.js
+++ b/index.js
@@ -8,26 +8,29 @@ module.exports = {
   name: 'ember-cli-yuidoc',
 
   postprocessTree: function(type, workingTree) {
-    if (this.app.env !== 'development' || type !== 'all' || !this.liveDocsEnabled){
-      return workingTree;
+    if(type === 'all') {
+      var env = this.app.env;
+      var config = optsGenerator.generate();
+
+      if((this.liveDocsEnabled && env === 'development') || (env === 'production' || config.buildInProduction === true)) {
+        return this.addDocsToTree(workingTree, config);
+      }
     }
-    return this.addDocsToTree(workingTree);
+    return workingTree;
   },
 
   included: function(){
     var cmdOpts = process.argv.slice(3);
-    this.liveDocsEnabled = cmdOpts.indexOf('--docs') !== -1
+    this.liveDocsEnabled = cmdOpts.indexOf('--docs') !== -1;
   },
 
   includedCommands: function() {
     return {
       'ember-cli-yuidoc': require('./lib/commands/ember-cli-yuidoc')
-    }
+    };
   },
 
-  addDocsToTree: function(inputTree){
-    var config = optsGenerator.generate();
-
+  addDocsToTree: function(inputTree, config){
     var yuidocTree = new YuidocCompiler(config.paths, config);
     return mergeTrees([inputTree, yuidocTree]);
   }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
       var env = this.app.env;
       var config = optsGenerator.generate();
 
-      if((this.liveDocsEnabled && env === 'development') || (env === 'production' || config.buildInProduction === true)) {
+      if((this.liveDocsEnabled && env === 'development') || (config.enabledEnvironments && config.enabledEnvironments.indexOf(env) !== -1)) {
         return this.addDocsToTree(workingTree, config);
       }
     }

--- a/lib/broccoli-yuidoc.js
+++ b/lib/broccoli-yuidoc.js
@@ -16,17 +16,17 @@ function BroccoliYuidoc(inputNodes, options) {
 };
 
 BroccoliYuidoc.prototype.build = function() {
-  this.paths = this.inputPaths;
-  this.outdir = path.resolve(this.outputPath, this.options.destDir);
+  var options = this.options;
+  options.paths = this.inputPaths;
+  options.outdir = path.resolve(this.outputPath, options.outdir);
 
-  var json = (new Y.YUIDoc(this)).run();
+  var json = (new Y.YUIDoc(options)).run();
 
-  if (this.options.yuidoc.parseOnly) {
+  if (this.options.parseOnly) {
     return;
   }
 
-  var builder = new Y.DocBuilder(this, json);
-
+  var builder = new Y.DocBuilder(options, json);
   return new rsvp.Promise(function(resolve) {
     builder.compile(function() { resolve(); });
   });

--- a/lib/broccoli-yuidoc.js
+++ b/lib/broccoli-yuidoc.js
@@ -17,7 +17,6 @@ function BroccoliYuidoc(inputNodes, options) {
 
 BroccoliYuidoc.prototype.build = function() {
   var options = this.options;
-  options.paths = this.inputPaths;
   options.outdir = path.resolve(this.outputPath, options.outdir);
 
   var json = (new Y.YUIDoc(options)).run();

--- a/lib/options.js
+++ b/lib/options.js
@@ -4,14 +4,6 @@ var getVersion  = require('git-repo-version');
 var fs          = require('fs');
 var Y           = require('yuidocjs');
 
-function defaultOption(options, name, defaultValue) {
-  if (!options) {
-    return defaultValue;
-  }
-
-  return options.hasOwnProperty(name) ? options[name] : defaultValue;
-}
-
 module.exports = {
   generate: function generateYuidocOptions(){
     var config;
@@ -32,29 +24,14 @@ module.exports = {
       process.exit(1);
     }
 
+    config.version = getVersion();
+    config.options.outdir = config.options.outdir || 'docs';
+
     if (exclusions.indexOf(config.options.exclude) === -1){
-      exclusions.push(config.options.exclude)
+      exclusions.push(config.options.exclude);
     }
+    config.options.exclude = exclusions.join(',');
 
-    var outDir = config.options.outdir || 'docs';
-    var yuidocOptions = config.options.yuidoc;
-
-    var options = Y.Project.init({
-      outdir: outDir,
-      destDir: outDir,
-      paths: config.options.paths || '.',
-      ignorePaths: ['tmp', 'node_modules'],
-      version: getVersion(),
-      external: config.external || config.options.external || {},
-      yuidoc: {
-        linkNatives: defaultOption(yuidocOptions, 'linkNatives',  true),
-        quiet: defaultOption(yuidocOptions, 'quiet', true),
-        parseOnly: defaultOption(yuidocOptions, 'parseOnly', false),
-        lint: defaultOption(yuidocOptions, 'lint', false),
-        exclude: exclusions.join(',')
-      }
-    });
-
-    return options;
+    return Y.Project.init(config);
   }
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,8 +27,15 @@ module.exports = {
     config.version = getVersion();
     config.options.outdir = config.options.outdir || 'docs';
 
-    if (exclusions.indexOf(config.options.exclude) === -1){
-      exclusions.push(config.options.exclude);
+    var confExclusions = config.options.exclude;
+    if(confExclusions && typeof confExclusions === 'string') {
+      confExclusions = confExclusions.split(',');
+      confExclusions.forEach(function(e) {
+        e = e.trim();
+        if(e !== '' && exclusions.indexOf(e) === -1) {
+          exclusions.push(e);
+        }
+      });
     }
     config.options.exclude = exclusions.join(',');
 


### PR DESCRIPTION
This propagates all config options passed in `yuidoc.json`throughout which allows a user to specify any supported yuidocs option such as `themedir`, `nocode`, etc. 

Works with `ember s --docs` and `ember ember-cli-yuidoc`