### PR TITLE
Rework commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ once with some sensitive defaults.
 
 ##  Usage
 
-### As an ember command
+### Building
 
-This addon adds a new `ember-cli-yuidoc` command to ember-cli to generate the documentation on demand. 
+This addon adds a new `yuidoc` command to ember-cli to generate the documentation on demand. 
 
-Just run `ember ember-cli-yuidoc` and your docs will apear in your output directory (`/docs` by default).
+Just run `ember yuidoc:build` and your docs will apear in your output directory (`/docs` by default).
 You probably want to add this folder to the `.gitignore`.
 
-### Watch mode
+### Serving
 
 This plugin also integrates with the ember server, so you can access your docs from the browser in the `/docs` urls.
 The documentation will update when you modify your code, as expected. 
 
 While this is specially useful if your are editing your documentation, it adds some overhead to your build pipeline,
-so this is disabled by default. Run `ember serve --docs` to enable it.
+so this is disabled by default. Run `ember yuidoc:serve` to enable it.
 
 ### Environment specific generation
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ module.exports = {
     if(type === 'all') {
       var env = this.app.env;
       var config = optsGenerator.generate();
-
-      if((this.liveDocsEnabled && env === 'development') || (config.enabledEnvironments && config.enabledEnvironments.indexOf(env) !== -1)) {
+      if(this.serveDocs || (config.enabledEnvironments && config.enabledEnvironments.indexOf(env) !== -1)) {
         return this.addDocsToTree(workingTree, config);
       }
     }
@@ -20,14 +19,12 @@ module.exports = {
   },
 
   included: function(){
-    var cmdOpts = process.argv.slice(3);
-    this.liveDocsEnabled = cmdOpts.indexOf('--docs') !== -1;
+    var cmdOpts = process.argv.slice(2);
+    this.serveDocs = cmdOpts.indexOf('yuidoc:serve') !== -1;
   },
 
   includedCommands: function() {
-    return {
-      'ember-cli-yuidoc': require('./lib/commands/ember-cli-yuidoc')
-    };
+    return require('./lib/commands');
   },
 
   addDocsToTree: function(inputTree, config){

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,12 +1,10 @@
 'use strict';
 
-
 module.exports = {
-  name: 'ember-cli-yuidoc',
+  name: 'yuidoc:build',
+  description: 'Builds html documentation using YUIDoc',
 
-  description: 'Generates html documentation using YUIDoc',
-
-  run: function(opts, rawArgs) {
+  run: function(/* commandOptions */) {
     var Y             = require('yuidocjs');
     var rsvp          = require('rsvp');
     var optsGenerator = require('../options');

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  'yuidoc:build': require('./build'),
+  'yuidoc:serve': require('./serve')
+};

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var EmberServe = require('ember-cli/lib/commands/serve');
+
+module.exports = {
+  name: 'yuidoc:serve',
+  description: 'Serves html documentation using YUIDoc',
+
+  beforeRun: function() {
+    this._emberServe = new EmberServe({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project,
+      tasks: this.tasks
+    });
+    this.availableOptions = this._emberServe.availableOptions;
+  },
+
+  run: function(commandOptions) {
+    return this._emberServe.run(commandOptions);
+  }
+};


### PR DESCRIPTION
Modularize the yuidoc commands and expose both `build` and `serve` options.

The `ember yuidoc:serve` creates a new ember-cli serve task and extends its options allowing you to do the following

`ember yuidoc:serve --port 9999 --environment=production`

Resolves #19 