### PR TITLE
Run Y.Project.init only when Yuidoc is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ module.exports = {
   postprocessTree: function(type, workingTree) {
     if(type === 'all') {
       var env = this.app.env;
-      var config = optsGenerator.generate();
+      var config = optsGenerator.load();
 
       if((this.liveDocsEnabled && env === 'development') || (config.enabledEnvironments && config.enabledEnvironments.indexOf(env) !== -1)) {
-        return this.addDocsToTree(workingTree, config);
+        return this.addDocsToTree(workingTree, optsGenerator.generate(config));
       }
     }
     return workingTree;

--- a/lib/options.js
+++ b/lib/options.js
@@ -5,8 +5,16 @@ var fs          = require('fs');
 var Y           = require('yuidocjs');
 
 module.exports = {
-  generate: function generateYuidocOptions(){
-    var config;
+  load: function loadYuidocOptions(){
+    try {
+      return JSON.parse(fs.readFileSync('yuidoc.json'));
+    } catch(e){
+      console.log("No yuidoc.json file in root folder. Run `ember g ember-cli-yuidoc` to generate one.");
+      process.exit(1);
+    }
+  },
+
+  generate: function generateYuidocOptions(config){
     var exclusions = [
       '.DS_Store',
       '.git',
@@ -17,11 +25,8 @@ module.exports = {
       'tests'
     ];
 
-    try {
-      config = JSON.parse(fs.readFileSync('yuidoc.json'));
-    } catch(e){
-      console.log("No yuidoc.json file in root folder. Run `ember g ember-cli-yuidoc` to generate one.");
-      process.exit(1);
+    if (!config) {
+      config = this.load();
     }
 
     config.version = getVersion();


### PR DESCRIPTION
`Y.Project.init` was always called (within `optsGenerator.generate`) even when yuidoc was not used. 

The problem is the `console.log` output of yuidoc itself (outputs things like "Scanning for yuidoc.json file."): when running `ember test` in a CI environment with the `--silent` flag, capturing output to a xunit file (see https://ember-cli.com/testing#ci-mode-with-testem), the console output of yuidoc (obviously not affected by `--silent`) would still find its way into that file, breaking xml and thus the whole build.

The small change makes sure that `init` is only called when a yuidoc run is really needed.