### PR TITLE
Fix loading of config.options.enabledEnvironments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = {
       var env = this.app.env;
       var config = optsGenerator.load();
 
-      if((this.liveDocsEnabled && env === 'development') || (config.enabledEnvironments && config.enabledEnvironments.indexOf(env) !== -1)) {
+      if((this.liveDocsEnabled && env === 'development') ||
+       (config.options && config.options.enabledEnvironments && config.options.enabledEnvironments.indexOf(env) !== -1)) {
         return this.addDocsToTree(workingTree, optsGenerator.generate(config));
       }
     }


### PR DESCRIPTION
Today a `config.options.enabledEnvironments` can be provided to allow generating docs in these envs. This is documented in README. However, `postprocessTree` method is looking for `config.enabledEnvironments`. Result is that `ember ember-cli-yuidoc` is working well but `ember build` never generates docs, even if the current environment is provided in conf. This fixes it.

... if this is not a documentation issue but I don't think so ....