### PR TITLE
Require yuidocjs lazily

### DIFF
--- a/lib/broccoli-yuidoc.js
+++ b/lib/broccoli-yuidoc.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Y       = require('yuidocjs');
 var rsvp    = require('rsvp');
 var path    = require('path');
 var CachingWriter = require('broccoli-caching-writer');
@@ -16,6 +15,7 @@ function BroccoliYuidoc(inputNodes, options) {
 };
 
 BroccoliYuidoc.prototype.build = function() {
+  var Y       = require('yuidocjs');
   var options = this.options;
   options.outdir = path.resolve(this.outputPath, options.outdir);
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -2,7 +2,6 @@
 
 var getVersion  = require('git-repo-version');
 var fs          = require('fs');
-var Y           = require('yuidocjs');
 
 module.exports = {
   load: function loadYuidocOptions(){
@@ -15,6 +14,7 @@ module.exports = {
   },
 
   generate: function generateYuidocOptions(config){
+    var Y          = require('yuidocjs');
     var exclusions = [
       '.DS_Store',
       '.git',


### PR DESCRIPTION
prevents unwanted side effects of yui's `process.on('uncaughtException')` (https://github.com/yui/yuidoc/blob/master/lib/index.js#L52). See https://github.com/ember-fastboot/ember-cli-fastboot/issues/285