### PR TITLE
[BUGFIX] Adds support for decorators

### DIFF
--- a/lib/broccoli-yuidoc.js
+++ b/lib/broccoli-yuidoc.js
@@ -3,6 +3,35 @@
 var rsvp    = require('rsvp');
 var path    = require('path');
 var CachingWriter = require('broccoli-caching-writer');
+var Y       = require('yuidocjs');
+
+var originalHandleComment = Y.DocParser.prototype.handlecomment;
+
+var AT_PLACEHOLDER = '---AT-PLACEHOLDER---';
+var AT_PLACEHOLDER_REGEX = new RegExp(AT_PLACEHOLDER, 'g');
+
+Y.DocParser.prototype.handlecomment = function(comment, file, line) {
+  var lines = comment.split(/\r\n|\n/);
+
+  var inMarkdownBlock = false;
+
+  var newLines = lines.map((line) => {
+    if (line.match(/^(\s*\*)?\s*```/)) {
+      inMarkdownBlock = !inMarkdownBlock;
+    }
+
+    return inMarkdownBlock ? line.replace(/@/g, AT_PLACEHOLDER) : line;
+  });
+
+  var ret = originalHandleComment.call(this, newLines.join('\n'), file, line);
+  var description = ret.find(t => t.tag === 'description');
+
+  if (description) {
+    description.value = description.value.replace(AT_PLACEHOLDER_REGEX, '@');
+  }
+
+  return ret;
+}
 
 BroccoliYuidoc.prototype = Object.create(CachingWriter.prototype);
 BroccoliYuidoc.prototype.constructor = BroccoliYuidoc;
@@ -15,7 +44,6 @@ function BroccoliYuidoc(inputNodes, options) {
 };
 
 BroccoliYuidoc.prototype.build = function() {
-  var Y       = require('yuidocjs');
   var options = this.options;
   options.outdir = path.resolve(this.outputPath, options.outdir);
 


### PR DESCRIPTION
This PR adds general support for decorators when used within markdown blocks.
It does this by reaching into the YUIDoc global and patching the method that
handles comment parsing. Given YUIDoc is pretty much abandoned at this point,
this should be a relatively stable patch. Presumably, attempts to modernize it
will also add decorator support, should they occur.

The fix replaces all @ symbols within codeblocks with a placeholder, processes
them, and then switches them back after processing.