### PR TITLE
[BUGFIX] Adds support for decorators in example code blocks

### DIFF
--- a/lib/broccoli-yuidoc.js
+++ b/lib/broccoli-yuidoc.js
@@ -30,6 +30,10 @@ Y.DocParser.prototype.handlecomment = function(comment, file, line) {
     description.value = description.value.replace(AT_PLACEHOLDER_REGEX, '@');
   }
 
+  ret.filter(t => t.tag === 'example').map(example => {
+    example.value = example.value.replace(AT_PLACEHOLDER_REGEX, '@');
+  });
+
   return ret;
 }
 


### PR DESCRIPTION
This extends the work done in #52 to add support for decorators inside example code blocks. I've tested these on the ember-source repo, so this should be good to merge.

//cc @rwjblue 